### PR TITLE
fix(table chart): Show Cell Bars correctly

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -409,7 +409,15 @@ export default function TableChart<D extends DataRecord = DataRecord>(
 
   const getColumnConfigs = useCallback(
     (column: DataColumnMeta, i: number): ColumnWithLooseAccessor<D> => {
-      const { key, label, isNumeric, dataType, isMetric, config = {} } = column;
+      const {
+        key,
+        label,
+        isNumeric,
+        dataType,
+        isMetric,
+        isPercentMetric,
+        config = {},
+      } = column;
       const columnWidth = Number.isNaN(Number(config.columnWidth))
         ? config.columnWidth
         : Number(config.columnWidth);
@@ -438,7 +446,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         (config.showCellBars === undefined
           ? showCellBars
           : config.showCellBars) &&
-        (isMetric || isRawRecords) &&
+        (isMetric || isRawRecords || isPercentMetric) &&
         getValueRange(key, alignPositiveNegative);
 
       let className = '';


### PR DESCRIPTION
### SUMMARY
The issue here is that the `isMetric` key for percentage metric is coming up as False from the columns when it is being imported from props. 

![image](https://github.com/apache/superset/assets/90512504/4ca6069a-ac0f-4d4c-bde7-15fe3c106581)


As we follow the data into the line where we are creating `const valueRange`, we can see that we are calling the `getValueRange` function only when either `isMetric` is True or `isRawRecords` is true.  `isRawRecords` is false for both, and `isMetric` is only true for regular metrics and not percentage metrics. So the `getValueRange` function is not even being called for percentage metrics which is why it is not calculated for these metrics.

![image](https://github.com/apache/superset/assets/90512504/6600007e-5974-4cc9-a36e-e6abb3a1e0ce)


When we follow the data further, we can see in the `<StyledCell>` component where we are returning the Cell Bars we have a condition of `valueRange` to not be null in order to display the cell bars. We can verify with console.logs that the `valueRange` is never calculated in the case of percentage metrics and it is null. This is why the cell bars are not showing up for only the percentage metrics because the css class for it is not being added since `valueRange` is null.

![image](https://github.com/apache/superset/assets/90512504/b941ad70-718b-4c08-8e3c-81e70a774bc9)


Proposed solution:

A solution that fixed the cell bars for me is adding a separate `key[0] == “%”` in the conditional where we are checking `(isMetric || isRawRecords)` while creating the `const “valueRange”` variable. This ensures none of the other code is messed with and the cell bars still show up.

As @michael-s-molina pointed out, we can make it better by using the `isPercentageMetric` property which already exists in `DataColumnMeta`. To do this I Imported it in the `getColumnConfigs` variable from `column` which was imported at the beginning of the file and placed it in the `valueRange` conditional.

![image](https://github.com/SA-Ark/apache-superset-dev/assets/90512504/7bc1a46a-7f46-4d47-972e-3ae3ab73559c)

End result:

Before:

![image](https://github.com/apache/superset/assets/90512504/26e9970b-1bfb-4a85-9155-bcb8ed8a6a05)

After:

![image](https://github.com/apache/superset/assets/90512504/be0af2eb-2762-4cc9-8434-a273e52866de)


### TESTING INSTRUCTIONS
Create a table chart and add both regular metrics and percentage metrics and enable the show cell bars options. They both should be showing when it previously was not.

### ADDITIONAL INFORMATION
Fixes #24495 - Show Cell Bars does not work on the Percentage Metrics in Table Chart

- [ ] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API